### PR TITLE
Bump Microsoft.Build to stable 17.10.46 for nuget.org publishing

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,8 @@
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
     <packageSource key="nuget">
       <package pattern="*" />
+	  <package pattern="Microsoft.Build" />
+	  <package pattern="Microsoft.Build.*" />
 	  <package pattern="Microsoft.Build.Tasks.Git" />
     </packageSource>
     <packageSource key="dotnet-tools">

--- a/Packages.props
+++ b/Packages.props
@@ -2,6 +2,6 @@
   <Import Project="dependabot\Packages.props" />
   <ItemGroup>
     <!-- <PackageVersion Include="Microsoft.Build" Version="17.8.0-preview-23424-02" /> -->
-	<PackageVersion Include="Microsoft.Build" Version="17.9.0-dev-23564-01" />
+	<PackageVersion Include="Microsoft.Build" Version="17.10.46" />
   </ItemGroup>
 </Project>

--- a/test/DotUtils.MsBuild.BinlogRedactor.Tests/BinlogComparer.cs
+++ b/test/DotUtils.MsBuild.BinlogRedactor.Tests/BinlogComparer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.BinlogRedactor.Tests
 
             void AddArchiveFile(Dictionary<string, string> files, ArchiveFileEventArgs arg)
             {
-                ArchiveFile embedFile = arg.ArchiveData.ToArchString();
+                ArchiveFile embedFile = arg.ArchiveData.ToArchiveFile();
                 string content = embedFile.Content;
                 files.Add(embedFile.FullPath, content);
             }


### PR DESCRIPTION
## Summary
The packages depend on `Microsoft.Build 17.9.0-dev-23564-01`, an internal prerelease dev build that is **not available on nuget.org**. Packing `DotUtils.MsBuild.BinlogRedactor` as a stable 1.0.0 therefore emits **`NU5104` (stable release should not have a prerelease dependency)** and produces an unrestorable package for nuget.org consumers.

This bumps `Microsoft.Build` to the public stable **`17.10.46`** — the lowest stable that:
- contains the binlog embedded-file streaming APIs the library uses (`OpenBuildEventsReader`, `BuildEventArgsReader.ArchiveFileEncountered`, `ToArchiveFileHandler`), which are **not** in 17.9.x stable; and
- is patched for **CVE-2025-55247** (GHSA-w3q9-fxm7-j8fq) — 17.10.4 etc. trigger `NU1903`.

## Changes
- **Packages.props**: `Microsoft.Build` `17.9.0-dev-23564-01` → `17.10.46`.
- **NuGet.config**: map `Microsoft.Build` / `Microsoft.Build.*` to the `nuget` source so the stable version restores from nuget.org (it was routed only to the internal dev feed).
- **test/BinlogComparer.cs**: `ArchiveData.ToArchString()` → `ToArchiveFile()` (the method was renamed in stable MSBuild).

## Validation
- All three packages pack with **no `NU5104` / `NU1903`** warnings.
- Full solution builds; **7/7 tests pass**.
- Final `DotUtils.MsBuild.BinlogRedactor` deps: `SensitiveDataDetector 1.0.0`, `Microsoft.Build 17.10.46`, `Microsoft.Extensions.Logging 8.0.0` — all stable and on nuget.org.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>